### PR TITLE
Options page: Fix --aq-mode option according to CLI help and source code from int to string

### DIFF
--- a/VCEEncC_Options.en.md
+++ b/VCEEncC_Options.en.md
@@ -81,7 +81,7 @@
   - [--cdf-update \[AV1\]](#--cdf-update-av1)
   - [--cdf-frame-end-update \[AV1\]](#--cdf-frame-end-update-av1)
   - [--temporal-layers \<int\> \[AV1\]](#--temporal-layers-int-av1)
-  - [--aq-mode \<int\> \[AV1\]](#--aq-mode-int-av1)
+  - [--aq-mode \<string\> \[AV1\]](#--aq-mode-string-av1)
   - [--pe](#--pe)
   - [--pa  \[\<param1\>=\<value1\>\[,\<param2\>=\<value2\>\]...\]](#--pa--param1value1param2value2)
   - [--slices \<int\> \[H.264/HEVC\]](#--slices-int-h264hevc)
@@ -578,7 +578,7 @@ Enable CDF frame end update.
 ### --temporal-layers &lt;int&gt; [AV1]
 Number of temporal layers.
 
-### --aq-mode &lt;int&gt; [AV1]
+### --aq-mode &lt;string&gt; [AV1]
 - **params**
   - none
   - caq 

--- a/VCEEncC_Options.ja.md
+++ b/VCEEncC_Options.ja.md
@@ -79,7 +79,7 @@
   - [--cdf-update \[AV1\]](#--cdf-update-av1)
   - [--cdf-frame-end-update \[AV1\]](#--cdf-frame-end-update-av1)
   - [--temporal-layers \<int\> \[AV1\]](#--temporal-layers-int-av1)
-  - [--aq-mode \<int\> \[AV1\]](#--aq-mode-int-av1)
+  - [--aq-mode \<string\> \[AV1\]](#--aq-mode-string-av1)
   - [--pe](#--pe)
   - [--pa  \[\<param1\>=\<value1\>\[,\<param2\>=\<value2\>\]...\]](#--pa--param1value1param2value2)
   - [--slices \<int\> \[H.264/HEVC\]](#--slices-int-h264hevc)
@@ -530,7 +530,7 @@ Enable CDF frame end update.
 ### --temporal-layers &lt;int&gt; [AV1]
 Temporal layersの数。
 
-### --aq-mode &lt;int&gt; [AV1]
+### --aq-mode &lt;string&gt; [AV1]
 AQモード。
 - **パラメータ**
   - none


### PR DESCRIPTION
I guess just a small typo, because the (string) options are set correctly.

Fixed both EN and JA option files...